### PR TITLE
`tasks/sub_package/install_subpackage_dependencies` should check if filename is directory

### DIFF
--- a/tasks/sub_package.py
+++ b/tasks/sub_package.py
@@ -87,7 +87,7 @@ def install_subpackage_dependencies(ctx, name=None, force=False):
     print_header("Sub-packages", icon="📦")
     print_header("Collecting dependencies", level=2, icon="🛒")
 
-    packages = os.listdir(PROJECT_INFO.namespace_directory) if name is None else [name]
+    packages = [directory for directory in (os.listdir(PROJECT_INFO.namespace_directory) if name is None else [name]) if os.path.isfile(directory)]
     all_requirements = ""
     libraries_to_sub_packages = defaultdict(list)
 


### PR DESCRIPTION
This is a minor suggestion to ensure the files listed in os.listdir are directories

This change assumes that the exception raised when requirements.txt is not found is desired.

Without checking if the filename is a directory, it will enforce the structure that no other files are allowed in the same directory.